### PR TITLE
Add custom Questions create controller to send emails to OPL curators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,7 +95,8 @@ logs
 results
 node_modules
 .node_history
-
+.env
+.env.local
 
 ############################
 # Tests

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ You will also need a MongoDB running locally or on a host you can reach from you
 
 Mongo running in a container is suggested (use [podman](https://podman.io/getting-started/installation) or [docker](https://docs.docker.com/get-docker/)).
 
+Environment variables are required to configure this service to send an email to curators when an AMA question is submitted.  
+```
+OPL_CONTENT_API_BASE_URL=http://localhost:1337
+SENDGRID_API_KEY=insert-real-sendgrid-key-here
+AMA_DEST_EMAIL=jibarton@redhat.com
+```
+If these aren't configured, the service will create the question and log a warning on the email send.
+
 You can run the application locally by cloning the repo and running:
 ```
 npm install

--- a/api/questions/controllers/questions.js
+++ b/api/questions/controllers/questions.js
@@ -30,13 +30,18 @@ module.exports = {
       entity = await strapi.services.questions.create(ctx.request.body);
     }
 
-    const message = emailPayload(entity, process.env.OPL_CONTENT_API_BASE_URL);
-    await strapi.plugins['email'].services.email.send({
-      to: process.env.AMA_DEST_EMAIL,
-      subject: 'OPL AMA New Question',
-      text: message.text,
-      html: message.html,
-    });
+    // only send email if destination email and sendgrid key are specified in envrionment
+    if (process.env.AMA_DEST_EMAIL && process.env.SENDGRID_API_KEY) {
+      const message = emailPayload(entity, process.env.OPL_CONTENT_API_BASE_URL);
+      await strapi.plugins['email'].services.email.send({
+        to: process.env.AMA_DEST_EMAIL,
+        subject: 'OPL AMA New Question',
+        text: message.text,
+        html: message.html,
+      });
+    } else {
+      console.log(`WARN: AMA email not sent: check for empty environment variables AMA_DEST_EMAIL=(${process.env.AMA_DEST_EMAIL}) or SENDGRID_API_KEY (exists? ${process.env.SENDGRID_API_KEY ? 'true' : 'false'})`);
+    }
 
     return sanitizeEntity(entity, { model: strapi.models.questions });
   },

--- a/api/questions/controllers/questions.js
+++ b/api/questions/controllers/questions.js
@@ -6,21 +6,7 @@
  */
 const { parseMultipartData, sanitizeEntity } = require('strapi-utils');
 
-const baseUrlMap = {
-  development: 'http://opl-content-api-opl-dev.apps.s44.core.rht-labs.com',
-  staging: 'http://opl-content-api-opl-staging.apps.s44.core.rht-labs.com',
-  production: 'http://opl-content-api-opl-staging.apps.s44.core.rht-labs.com',
-};
-const baseUrl = baseUrlMap[process.env.NODE_ENV];
-
-const amaDestEmailMap = {
-  development: 'openpracticelibraryteam@gmail.com',
-  staging: 'openpracticelibraryteam@gmail.com',
-  production: 'openpracticelibraryteam@gmail.com',
-};
-const amaDestEmail = amaDestEmailMap[process.env.NODE_ENV];
-
-function emailPayload(entity) {
+function emailPayload(entity, baseUrl) {
   const html = (`
     <p>New Question: <a href="${baseUrl}/admin/plugins/content-manager/collectionType/application::questions.questions/${entity.id}?redirectUrl=/plugins/content-manager/collectionType/application::questions.questions">${entity.question}</a>
     <p><a href="${baseUrl}/admin/plugins/content-manager/collectionType/application::answers.answers">Create Answer</a>
@@ -44,9 +30,9 @@ module.exports = {
       entity = await strapi.services.questions.create(ctx.request.body);
     }
 
-    const message = emailPayload(entity);
+    const message = emailPayload(entity, process.env.OPL_CONTENT_API_BASE_URL);
     await strapi.plugins['email'].services.email.send({
-      to: amaDestEmail,
+      to: process.env.AMA_DEST_EMAIL,
       subject: 'OPL AMA New Question',
       text: message.text,
       html: message.html,

--- a/api/questions/controllers/questions.js
+++ b/api/questions/controllers/questions.js
@@ -4,5 +4,54 @@
  * Read the documentation (https://strapi.io/documentation/3.0.0-beta.x/concepts/controllers.html#core-controllers)
  * to customize this controller
  */
+const { parseMultipartData, sanitizeEntity } = require('strapi-utils');
 
-module.exports = {};
+const baseUrlMap = {
+  development: 'http://opl-content-api-opl-dev.apps.s44.core.rht-labs.com',
+  staging: 'http://opl-content-api-opl-staging.apps.s44.core.rht-labs.com',
+  production: 'http://opl-content-api-opl-staging.apps.s44.core.rht-labs.com',
+};
+const baseUrl = baseUrlMap[process.env.NODE_ENV];
+
+const amaDestEmailMap = {
+  development: 'openpracticelibraryteam@gmail.com',
+  staging: 'openpracticelibraryteam@gmail.com',
+  production: 'openpracticelibraryteam@gmail.com',
+};
+const amaDestEmail = amaDestEmailMap[process.env.NODE_ENV];
+
+function emailPayload(entity) {
+  const html = (`
+    <p>New Question: <a href="${baseUrl}/admin/plugins/content-manager/collectionType/application::questions.questions/${entity.id}?redirectUrl=/plugins/content-manager/collectionType/application::questions.questions">${entity.question}</a>
+    <p><a href="${baseUrl}/admin/plugins/content-manager/collectionType/application::answers.answers">Create Answer</a>
+    <p>Questioner: ${entity.questionerName} - ${entity.questionerEmail}
+    <p>Created: ${entity.createdAt}
+  `);
+  return {
+    html: html,
+    text: html.replace(/<\/?[^>]+(>|$)/g, '')
+  };
+}
+
+module.exports = {
+  // Override default create controller for Questions to send email for question eval and response
+  async create(ctx) {
+    let entity;
+    if (ctx.is('multipart')) {
+      const { data, files } = parseMultipartData(ctx);
+      entity = await strapi.services.questions.create(data, { files });
+    } else {
+      entity = await strapi.services.questions.create(ctx.request.body);
+    }
+
+    const message = emailPayload(entity);
+    await strapi.plugins['email'].services.email.send({
+      to: amaDestEmail,
+      subject: 'OPL AMA New Question',
+      text: message.text,
+      html: message.html,
+    });
+
+    return sanitizeEntity(entity, { model: strapi.models.questions });
+  },
+};

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,9 +1,19 @@
-module.exports = {
+module.exports = ({ env }) => ({
   graphql: {
     endpoint: '/graphql',
     shadowCRUD: true,
     playgroundAlways: true,
     federation: true
   },
-};
+  email: {
+    provider: 'sendgrid',
+    providerOptions: {
+      apiKey: env('SENDGRID_API_KEY'),
+    },
+    settings: {
+      defaultFrom: 'openpracticelibraryteam@gmail.com',
+      defaultReplyTo: 'openpracticelibraryteam@gmail.com',
+    },
+  },
+});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3381,6 +3381,41 @@
       "resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.4.tgz",
       "integrity": "sha512-YXJqp9gdHcZKAmBY/WnwFpPtNQp2huD/ME2YMurH2YHJvxrVzYsmpKw/pb7yINArRpp8E++fwbQd3ajYXGA45Q=="
     },
+    "@sendgrid/client": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-6.5.5.tgz",
+      "integrity": "sha512-Nbfgo94gbWSL8PIgJfuHoifyOJJepvV8NQkkglctAEfb1hyozKhrzE6v1kPG/z4j0RodaTtXD5LJj/t0q/VhLA==",
+      "requires": {
+        "@sendgrid/helpers": "^6.5.5",
+        "@types/request": "^2.48.4",
+        "request": "^2.88.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-6.5.5.tgz",
+      "integrity": "sha512-uRFEanalfss5hDsuzVXZ1wm7i7eEXHh1py80piOXjobiQ+MxmtR19EU+gDSXZ+uMcEehBGhxnb7QDNN0q65qig==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "deepmerge": "^4.2.2"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        }
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-6.4.0.tgz",
+      "integrity": "sha512-pVzbqbxhZ4FUN6iSIksRLtyXRPurrcee1i0noPDStDCLlHVwUR+TofeeKIFWGpIvbbk5UR6S6iV/U5ie8Kdblw==",
+      "requires": {
+        "@sendgrid/client": "^6.4.0",
+        "@sendgrid/helpers": "^6.4.0"
+      }
+    },
     "@sentry/apm": {
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.16.0.tgz",
@@ -3574,6 +3609,11 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/color-name": {
       "version": "1.1.1",
@@ -3860,6 +3900,29 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/request": {
+      "version": "2.48.5",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
@@ -3874,6 +3937,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "@types/ws": {
       "version": "7.2.4",
@@ -17147,6 +17215,36 @@
         "strapi-helper-plugin": "3.0.0",
         "strapi-utils": "3.0.1",
         "uuid": "^3.1.0"
+      }
+    },
+    "strapi-provider-email-sendgrid": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/strapi-provider-email-sendgrid/-/strapi-provider-email-sendgrid-3.0.5.tgz",
+      "integrity": "sha512-ViIbIFAzNUm2op4Lj+De99m28b6bDHLIC0Rw9Zrs8g1bHt4IRBPFChlziTLNAoUOi0Q4E7fCVClZIp7SUL6GTQ==",
+      "requires": {
+        "@sendgrid/mail": "6.4.0",
+        "strapi-utils": "3.0.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.12",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.12.tgz",
+          "integrity": "sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA=="
+        },
+        "strapi-utils": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/strapi-utils/-/strapi-utils-3.0.5.tgz",
+          "integrity": "sha512-XcVZgdBzk9SHwePk6IUMibJ5/z4aQDrVo3l97a/19QEJmVRYPkJfSYQfxV+6A41HaiHGN+kKbIgG4lAlT4dN0w==",
+          "requires": {
+            "@sindresorhus/slugify": "^0.11.0",
+            "date-fns": "^2.8.1",
+            "lodash": "4.17.12",
+            "pino": "^4.7.1",
+            "pluralize": "^7.0.0",
+            "shelljs": "^0.8.3",
+            "yup": "0.28.1"
+          }
+        }
       }
     },
     "strapi-provider-email-sendmail": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "strapi-plugin-mongodb-files": "^3.0.0-beta.20.2",
     "strapi-plugin-upload": "3.0.1",
     "strapi-plugin-users-permissions": "3.0.1",
+    "strapi-provider-email-sendgrid": "^3.0.5",
     "strapi-provider-upload-mongodb": "^3.0.0-beta.20.5",
     "strapi-utils": "3.0.1"
   },


### PR DESCRIPTION
Resolves #9 

Configured Strapi email plugin to use sendgrid to send Question emails to OPL curators.  Added SENDGRID_API_KEY as secrets to both opl-dev and staging projects.
https://console-openshift-console.apps.s44.core.rht-labs.com/k8s/ns/opl-dev/secrets/opl-content-api-secrets

Sends email with question info and links to strapi admin interfaces to openpracticelibraryteam@gmail.com.  Strapi admin URL and target email address are configurable based on deployment stage as defined by NODE_ENV variable.

Potential Issues:
- Email target address would be better using @openpracticelibrary.com .  We can't do that until we replace our current single sender auth to sendgrid with domain auth. We need access to our DNS records before we can enable that.
https://sendgrid.com/docs/ui/account-and-settings/how-to-set-up-domain-authentication/

- RE management of our secret SENDGRID_API_KEY, @shaheinm said this: "API Keys and such should be stored in secrets, which, for now, have to be manually input in s44, but you would still update opl-cd deployments to reference them."  I haven't made any opl-cd changes yet.